### PR TITLE
Reconhecer fase plenário quando é incluida na ordem do dia

### DIFF
--- a/R/senado_analyzer.R
+++ b/R/senado_analyzer.R
@@ -374,7 +374,7 @@ extract_locais <- function(df) {
         dplyr::case_when(
           situacao_descricao_situacao == senado_env$fase_global_sancao$situacao_sancao ~ senado_constants$presidencia,
           (situacao_descricao_situacao %in% senado_constants$regex_plenario) |
-            (situacao_descricao_situacao %in% senado_constants$incluido_ordem_dia & sigla_local == "PLEN") ~
+            (situacao_descricao_situacao %in% senado_constants$incluido_ordem_dia) ~
             senado_constants$plenario,
           (
             stringr::str_detect(
@@ -598,6 +598,7 @@ extract_casas_in_senado <- function(data_tramitacao, casa_name) {
       local =
         dplyr::case_when(
           situacao_descricao_situacao == fase_global_presidencia$situacao_sancao ~ senado_constants$presidencia,
-          (stringr::str_detect(tolower(texto_tramitacao), fase_global_constants$plenario) & sigla_local == "PLEN") ~ senado_constants$plenario,
+          (stringr::str_detect(tolower(texto_tramitacao), fase_global_constants$plenario) & sigla_local == "PLEN") |
+            (stringr::str_detect(tolower(texto_tramitacao), "incluíd(a|o) (em|na) ordem do dia da sessão deliberativa.*")) ~ senado_constants$plenario,
           sigla_local %in% senado_env$comissoes_nomes$siglas_comissoes & (!stringr::str_detect(tolower(texto_tramitacao), fase_global_constants$plenario)) ~ senado_constants$comissoes))
 }


### PR DESCRIPTION
Nesta [PLS](https://www25.senado.leg.br/web/atividade/materias/-/materia/121572), ela teve a fase `plenário - construção` mas não estava sendo reconhecida pois a sigla do local é uma secretaria.

Conversando com Saulo, ele disse que quando acontece o evento `incluída em ordem do dia` sempre é plenário, mesmo que o local seja outro. Então mudei a lógica do progresso para isso.