### PR TITLE
Remove links de inteiro teor do senado

### DIFF
--- a/R/tramitacoes.R
+++ b/R/tramitacoes.R
@@ -6,18 +6,13 @@
 #' @examples
 #' fetch_tramitacao_senado(91341)
 fetch_tramitacao_senado <- function(prop_id) {
-    textos <- 
-      extract_links_proposicao_senado(prop_id) %>%
-      dplyr::select(data_hora = data,
-                    link_inteiro_teor) %>%
-      dplyr::mutate(data_hora = as.POSIXct(data_hora, tz = "UTC"))
-  
-    tramitacao <- rcongresso::fetch_tramitacao_senado(prop_id) %>%
+    rcongresso::fetch_tramitacao_senado(prop_id) %>%
       dplyr::mutate(data_hora = lubridate::ymd_hm(paste(data_hora, "00:00")),
                     prop_id = as.integer(codigo_materia),
                     sequencia = as.integer(sequencia),
                     id_situacao = as.integer(situacao_codigo_situacao),
-                    casa = "senado") %>%
+                    casa = "senado",
+                    link_inteiro_teor = "") %>%
       dplyr::select(prop_id,
                     casa,
                     data_hora,
@@ -25,9 +20,8 @@ fetch_tramitacao_senado <- function(prop_id) {
                     texto_tramitacao,
                     sigla_local = origem_tramitacao_local_sigla_local,
                     id_situacao,
-                    descricao_situacao = situacao_descricao_situacao) %>%
-      dplyr::left_join(textos, by = "data_hora")
-    
+                    descricao_situacao = situacao_descricao_situacao,
+                    link_inteiro_teor)
 }
 
 #' @title Baixa os dados da tramitação de um Projeto de Lei


### PR DESCRIPTION
#341 
Tendo em vista que em alguns casos como emendas há bem mais links do que linhas na tramitação eu decedi por não adicionar essas várias linhas a mais a tabela de tramitação da proposição, caso o usuário necessite dos links para os documentos ele poderá utilizar da função: extract_links_proposicao_senado()