### PR TITLE
Adiciona ids padronizados para os parlamentares considerando o enum da casa de origem

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -191,21 +191,35 @@ formata_nome_eleitoral <- function(nome, partido, uf) {
 #' @description Recebe a string do senador retornada pela api do Seando
 #' e retorna Sen. nome.
 #' @param nome_autor Nome do parlamentar
+#' @param tipo_autor Tipo do Autor (deputado ou senador)
 #' @return String
 #' @export
-formata_nome_senadores <- function(nome_autor) {
-  stringr::str_replace(nome_autor,
-                       "(\\()(.*?)(\\))|(^Deputad(o|a) Federal )|(^Deputad(o|a) )|(^Senador(a)* )|(^Líder do ((.*?)(\\s)))|(^Presidente do Senado Federal: Senador )", "Sen. ")
+formata_nome_senadores <- function(nome_autor, tipo_autor) {
+  if (tolower(tipo_autor) == "senador") {
+    return(stringr::str_replace(nome_autor,
+                                "(\\()(.*?)(\\))|(^Senador(a)* )|(^Líder do ((.*?)(\\s)))|(^Presidente do Senado Federal: Senador )", "Sen. "))
+  } else if (tolower(tipo_autor) == "deputado") {
+    return(stringr::str_replace(nome_autor,
+                                "(\\()(.*?)(\\))|(^Deputad(o|a) Federal )|(^Deputad(o|a) )", "Dep. "))
+  } else {
+    return(nome_autor)
+  }
+
 }
 
 #' @title Formata o nome dos deputados
 #' @description Recebe o nome do deputado
 #' e retorna Dep. nome.
 #' @param nome_autor Nome do parlamentar
+#' @param tipo_autor Tipo do Autor (deputado ou senador)
 #' @return String
 #' @export
-formata_nome_deputados <- function(nome_autor) {
-  paste0('Dep. ', nome_autor)
+formata_nome_deputados <- function(nome_autor, tipo_autor) {
+  if (tolower(tipo_autor) == "deputado") {
+    return(paste0('Dep. ', nome_autor))
+  } else {
+    return(nome_autor)
+  }
 }
 
 #' @title Padroniza um texto

--- a/scripts/documentos/export_atores.R
+++ b/scripts/documentos/export_atores.R
@@ -1,0 +1,39 @@
+#' @title Exporta dados atores
+#' @description Processa e escreve os dados de atores
+#' @param camara_docs documentos da camara
+#' @param senados_docs documentos do senado
+#' @param camara_autores autores da camara
+#' @param senado_autores autores do senado
+#' @param data_inicio data a partir da qual se considerará os documentos
+#' @param peso_minimo limiar para peso dos documentos
+#' @param output_path pasta para onde exportar os dados
+export_atores <- function(camara_docs, camara_autores, senado_docs, senado_autores, output_path, data_inicio, peso_minimo, props_leggo_id) {
+  print(paste("Gerando tabela de atores a partir de dados atualizados de documentos e autores..."))
+  
+  atores_camara <- agoradigital::create_tabela_atores_camara(camara_docs, camara_autores, data_inicio = data_inicio, limiar = peso_minimo) %>% 
+    select(id_ext, casa, id_autor, tipo_autor, tipo_generico, sigla_local, peso_total_documentos, num_documentos, partido, uf, nome_autor, is_important)
+  
+  atores_senado <- agoradigital::create_tabela_atores_senado(senado_docs, senado_autores, data_inicio = data_inicio, limiar = peso_minimo) %>% 
+    select(id_ext, casa, id_autor, tipo_autor, tipo_generico, sigla_local, peso_total_documentos, num_documentos, partido, uf, nome_autor, is_important)
+  
+  .PARTIDOS_OPOSICAO <-
+    c("PT", "PSOL", "PSB", "PCdoB", "PDT", "REDE")
+  
+  if ((nrow(atores_camara) > 0) | (nrow(atores_senado) > 0)) {
+    atores_df <-
+      dplyr::bind_rows(atores_camara, atores_senado) %>%
+      dplyr::mutate(bancada = dplyr::if_else(partido %in% .PARTIDOS_OPOSICAO, "oposição", "governo")) %>%
+      dplyr::left_join(props_leggo_id, by = c("id_ext"="id_principal", "casa")) %>%
+      dplyr::mutate(casa_autor = dplyr::if_else(tolower(tipo_autor) == "deputado", 
+                                                "camara",
+                                                "senado")) %>% 
+      dplyr::mutate(id_autor_parlametria = paste0(dplyr::if_else(casa_autor == "camara", 1, 2),
+                                           id_autor)) %>% 
+      dplyr::select(id_leggo, id_autor_parlametria, dplyr::everything())
+  } else {
+    atores_df <- tibble::tribble(~id_leggo, ~id_autor_parlametria, ~id_ext, ~casa, ~id_autor, ~tipo_autor, ~tipo_generico, ~sigla_local,
+                                 ~peso_total_documentos, ~num_documentos, ~partido, ~uf, ~nome_autor, ~is_important, ~bancada, ~casa_autor)
+  }
+  
+  readr::write_csv(atores_df, paste0(output_path, '/atores.csv'), na = "")
+}

--- a/scripts/documentos/export_coautorias.R
+++ b/scripts/documentos/export_coautorias.R
@@ -1,0 +1,169 @@
+#' @title Exporta dados de autorias e coautorias na Câmara
+#' @description Processa e escreve os dados de autorias e coautorias na Câmara
+#' @param camara_docs documentos da camara
+#' @param data_inicial data a partir da qual se considerará os documentos
+#' @param camara_autores autores da camara
+#' @param peso_minimo limiar para peso das arestas
+#' @param props_leggo_id proposições a serem filtradas
+#' @param output_path caminho para onde os arquivos serão exportados
+.generate_coautorias_camara <- function(camara_docs, data_inicial, camara_autores, peso_minimo, props_leggo_id, output_path) {
+  coautorias_camara <- tibble::tibble()
+  autorias_camara <- tibble::tibble()
+  
+  print("Gerando tabela de autorias e coautorias para a Câmara...")
+  
+  camara_documentos <-
+    camara_docs %>%
+    dplyr::mutate(data = lubridate::floor_date(data_apresentacao, unit='day')) %>%
+    dplyr::filter(data > data_inicial) %>%
+    dplyr::left_join(props_leggo_id, by = c("id_principal", "casa"))
+  
+  # Gerando dado de autorias de documentos
+  if (nrow(camara_documentos) > 0) {
+    coautorias_camara_list <- agoradigital::get_coautorias(camara_documentos, camara_autores, "camara", as.numeric(peso_minimo), .PARTIDOS_OPOSICAO)
+    coautorias_camara <- coautorias_camara_list$coautorias
+    autorias_camara <- coautorias_camara_list$autorias
+  }
+  
+  if (nrow(coautorias_camara) > 0) {
+    coautorias <-
+      coautorias_camara %>%
+      dplyr::mutate(partido.x = dplyr::if_else(is.na(partido.x), "", partido.x),
+                    partido.y = dplyr::if_else(is.na(partido.y), "", partido.y))
+    
+    autorias <-
+      autorias_camara %>% 
+      dplyr::mutate(autores = purrr::map_chr(nome_eleitoral, ~ paste(.x, collapse = ", "))) %>% 
+      dplyr::distinct()
+    
+  } else {
+    coautorias <- tibble::tibble(~id_leggo, ~id_principal, ~casa, ~id_autor.x, ~id_autor.y, ~peso_arestas, ~num_coautorias, 
+                                 ~nome.x, ~partido.x, ~uf.x, ~casa_autor.x, ~bancada.x, ~nome.y, ~partido.y, ~uf.y, ~casa_autor.y,
+                                 ~bancada.y)
+    autorias <- tibble::tribble(~id_principal, ~casa, ~id_documento, ~descricao_tipo_documento, ~id_autor, ~data, 
+                                ~url_inteiro_teor, ~id_leggo, ~casa_autor, ~nome_eleitoral, ~autores)
+  }
+  
+  readr::write_csv(coautorias, paste0(output_path, '/camara/coautorias.csv'))
+  readr::write_csv(autorias, paste0(output_path, '/camara/autorias.csv'))
+}
+
+#' @title Exporta dados de autorias e coautorias no Senado
+#' @description Processa e escreve os dados de autorias e coautorias no Senado
+#' @param senados_docs documentos do senado
+#' @param data_inicial data a partir da qual se considerará os documentos
+#' @param senado_autores autores do senado
+#' @param peso_minimo limiar para peso das arestas
+#' @param props_leggo_id proposições a serem filtradas
+#' @param output_path pasta para onde exportar os dados
+.generate_coautorias_senado <- function(senado_docs, data_inicial, senado_autores, peso_minimo, props_leggo_id, output_path) {
+  coautorias_senado <- tibble::tibble()
+  autorias_senado <- tibble::tibble()
+  
+  print("Gerando tabela de autorias e coautorias no Senado...")
+  
+  senado_documentos <-
+    senado_docs %>%
+    dplyr::filter(data_texto > data_inicial) %>%
+    dplyr::left_join(props_leggo_id, by = c("id_principal", "casa"))
+  
+  # Gerando dado de autorias de documentos
+  if (nrow(senado_documentos) > 0) {
+    coautorias_senado_list <- agoradigital::get_coautorias(senado_documentos, senado_autores, "senado", as.numeric(peso_minimo), .PARTIDOS_OPOSICAO)
+    coautorias_senado <- coautorias_senado_list$coautorias
+    autorias_senado <- coautorias_senado_list$autorias
+  }
+  
+  if (nrow(coautorias_senado) > 0) {
+    coautorias <-
+      coautorias_senado %>%
+      dplyr::mutate(partido.x = dplyr::if_else(is.na(partido.x), "", partido.x),
+                    partido.y = dplyr::if_else(is.na(partido.y), "", partido.y))
+    
+    autorias <-
+      autorias_senado %>% 
+      dplyr::mutate(autores = purrr::map_chr(nome_eleitoral, ~ paste(.x, collapse = ", "))) %>% 
+      dplyr::distinct()
+    
+  } else {
+    coautorias <- tibble::tibble(~id_leggo, ~id_principal, ~casa, ~id_autor.x, ~id_autor.y, ~peso_arestas, ~num_coautorias, 
+                                 ~nome.x, ~partido.x, ~uf.x, ~casa_autor.x, ~bancada.x, ~nome.y, ~partido.y, ~uf.y, 
+                                 ~casa_autor.y, ~bancada.y)
+    autorias <- tibble::tribble(~id_principal, ~casa, ~id_documento, ~descricao_tipo_documento, ~id_autor, ~data, 
+                                ~url_inteiro_teor, ~id_leggo, ~casa_autor, ~nome_eleitoral, ~autores)
+  }
+  
+  readr::write_csv(coautorias, paste0(output_path, '/senado/coautorias.csv'))
+  readr::write_csv(autorias, paste0(output_path, '/senado/autorias.csv'))
+}
+
+#' @title Exporta dados de nodes e edges
+#' @description Processa e escreve os dados de nodes e edges
+#' @param input_path pasta para onde importar os dados.
+#' @param camara_docs documentos da camara
+#' @param data_inicial data a partir da qual se considerará os documentos
+#' @param senados_docs documentos do senado
+#' @param camara_autores autores da camara
+#' @param peso_minimo limiar para peso das arestas
+#' @param senado_autores autores do senado
+#' @param output_path pasta para onde exportar os dados
+export_nodes_edges <- function(input_path, camara_docs, data_inicial, senado_docs, camara_autores, peso_minimo, senado_autores, props_leggo_id, output_path) {
+  
+  .generate_coautorias_camara(camara_docs, data_inicial, camara_autores, peso_minimo, props_leggo_id, output_path)
+  .generate_coautorias_senado(senado_docs, data_inicial, senado_autores, peso_minimo, props_leggo_id, output_path)
+  
+  coautorias_camara <- readr::read_csv(paste0(output_path, '/camara/coautorias.csv'))
+  autorias_camara <- readr::read_csv(paste0(output_path, '/camara/autorias.csv'))
+  
+  coautorias_senado <- readr::read_csv(paste0(output_path, '/senado/coautorias.csv'))
+  autorias_senado <- readr::read_csv(paste0(output_path, '/senado/autorias.csv'))
+  
+  if ((nrow(coautorias_camara) > 0) | (nrow(coautorias_senado) > 0)) {
+    
+    names(autorias_senado)
+    names(autorias_camara)
+    coautorias <-
+      dplyr::bind_rows(coautorias_camara, coautorias_senado) %>%
+      dplyr::mutate(partido.x = dplyr::if_else(is.na(partido.x), "", partido.x),
+                    partido.y = dplyr::if_else(is.na(partido.y), "", partido.y))
+    
+    autorias <-
+      dplyr::bind_rows(autorias_camara %>% 
+                         mutate(data = as.Date(data, format = "%Y-%m-%d")), 
+                       autorias_senado %>% 
+                         mutate(data = as.Date(data, format = "%Y-%m-%d"))) %>% 
+      dplyr::distinct() %>% 
+      dplyr::mutate(id_autor_parlametria = paste0(dplyr::if_else(casa_autor == "camara", 1, 2),
+                                                  id_autor))
+    
+    nodes <-
+      agoradigital::get_unique_nodes(coautorias)
+    
+    edges <-
+      coautorias %>%
+      dplyr::group_by(id_leggo) %>%
+      dplyr::group_modify(~ agoradigital::generate_edges(., graph_nodes = nodes, edges_weight = 1), keep = T) %>%
+      dplyr::distinct()
+    
+    nodes <-
+      agoradigital::compute_nodes_size(edges, nodes) %>% 
+      dplyr::mutate(id_autor_parlametria = paste0(dplyr::if_else(casa_autor == "camara", 1, 2),
+                                                  id_autor))
+    
+    edges <-
+      edges %>%
+      dplyr::filter(source != target)
+  } else {
+    nodes <- tibble::tribble(~id_leggo, ~id_autor, ~nome, ~partido, ~uf, ~bancada, ~casa_autor, ~nome_eleitoral, 
+                             ~node_size, ~id_autor_parlametria)
+    edges <- tibble::tribble(~id_leggo, ~source, ~target, ~value)
+    autorias <- tibble::tribble(~id_principal, ~casa, ~id_documento, ~descricao_tipo_documento, ~id_autor,
+                                ~data, ~url_inteiro_teor, ~id_leggo, ~casa_autor, ~nome_eleitoral, ~autores, 
+                                ~id_autor_parlametria)
+  }
+  
+  readr::write_csv(nodes , paste0(output_path, '/coautorias_nodes.csv'), na = "")
+  readr::write_csv(edges, paste0(output_path, '/coautorias_edges.csv'), na = "")
+  readr::write_csv(autorias, paste0(output_path, '/autorias.csv'))
+}
+

--- a/scripts/documentos/export_emendas.R
+++ b/scripts/documentos/export_emendas.R
@@ -1,0 +1,91 @@
+#' @title Exporta dados de emendas para análise
+#' @description Processa e escreve os dados de emendas
+#' @param camara_docs documentos da camara
+#' @param senados_docs documentos do senado
+#' @param camara_autores autores da camara
+#' @param senado_autores autores do senado
+#' @param output_path pasta para onde exportar os dados
+#' @return dataframe com novas emendas a serem analisadas
+export_emendas <- function(camara_docs, camara_autores, senado_docs, senado_autores, output_path) {
+  print(paste("Gerando tabela de emendas para análise a partir de dados atualizados de documentos e autores..."))
+  
+  emendas_camara <- camara_docs %>% dplyr::filter(sigla_tipo %in% agoradigital::get_envvars_camara()$tipos_emendas$sigla) %>% 
+    dplyr::inner_join(camara_autores %>% 
+                        mutate(id_principal = as.numeric(id_principal)), 
+                      by=c('id_principal', 'id_documento', 'casa')) %>% 
+    dplyr::mutate(nome_partido_uf = paste0(nome, ' ', partido, '/', uf),
+                  data_apresentacao = as.Date(data_apresentacao)) %>% 
+    dplyr::group_by(id_ext = id_principal, 
+                    codigo_emenda = id_documento, 
+                    data_apresentacao, 
+                    numero, 
+                    local = status_proposicao_sigla_orgao, 
+                    casa, 
+                    tipo_documento = sigla_tipo,
+                    inteiro_teor = url_inteiro_teor) %>% 
+    dplyr::summarise(autor = paste(nome_partido_uf, collapse = ', ')) %>% 
+    dplyr::ungroup() %>% 
+    dplyr::select(id_ext, codigo_emenda, data_apresentacao, numero, local, autor, casa, tipo_documento, inteiro_teor)
+  
+  emendas_senado <- senado_docs %>% dplyr::filter(descricao_tipo_texto %in% agoradigital::get_envvars_senado()$tipos_emendas$descricao_tipo_texto) %>% 
+    dplyr::inner_join(senado_autores, by=c('id_principal','id_documento','casa')) %>% 
+    dplyr::mutate(nome_partido_uf = paste0(nome_autor, ' ', partido, '/', uf),
+                  numero = as.integer(numero_emenda),
+                  data_apresentacao = lubridate::ymd(data_texto)) %>% 
+    dplyr::group_by(id_ext = id_principal, 
+                    codigo_emenda = id_documento, 
+                    data_apresentacao, 
+                    numero, 
+                    local = identificacao_comissao_sigla_comissao, 
+                    casa, 
+                    tipo_documento = descricao_tipo_texto,
+                    inteiro_teor = url_texto) %>% 
+    dplyr::summarise(autor = paste(nome_partido_uf, collapse = ', ')) %>% 
+    dplyr::ungroup() %>% 
+    dplyr::select(id_ext, codigo_emenda, data_apresentacao, numero, local, autor, casa, tipo_documento, inteiro_teor)
+  
+  emendas <- dplyr::bind_rows(emendas_camara, emendas_senado)
+  
+  novas_emendas <- agoradigital::update_emendas_files(emendas, output_path)
+}
+
+#' @title Exporta dados de avulsos iniciais para análise
+#' @description Processa e escreve os dados de avulsos iniciais
+#' @param camara_docs documentos da camara
+#' @param senados_docs documentos do senado
+#' @param novas_emendas novas emendas a serem analisadas
+#' @param output_path pasta para onde exportar os dados
+export_avulsos_iniciais <- function(camara_docs, senado_docs, novas_emendas, output_path) {
+  print(paste("Gerando tabela de avulsos iniciais dos PLs para análise a partir de dados atualizados de documentos..."))
+  
+  av_iniciais_camara <- camara_docs %>% dplyr::filter(id_documento == id_principal) %>% 
+    dplyr::mutate(data = as.Date(data_apresentacao)) %>% 
+    dplyr::select(id_proposicao = id_principal,
+                  casa,
+                  codigo_texto = id_documento,
+                  data,
+                  tipo_texto = descricao_tipo_documento,
+                  inteiro_teor = url_inteiro_teor) %>% 
+    dplyr::distinct()
+  
+  
+  av_iniciais_senado <- senado_docs %>% dplyr::filter(stringr::str_detect(tolower(descricao_texto), 'avulso inicial da mat.ria')) %>% 
+    dplyr::select(id_proposicao = id_principal,
+                  casa,
+                  codigo_texto = id_documento,
+                  data = data_texto,
+                  tipo_texto = descricao_tipo_texto,
+                  inteiro_teor = url_texto)
+  
+  av_iniciais <- dplyr::bind_rows(av_iniciais_camara, av_iniciais_senado)
+  
+  av_iniciais_novas_emendas <- av_iniciais %>% 
+    dplyr::inner_join(novas_emendas %>% 
+                        dplyr::select(id_proposicao = id_ext, casa) %>% 
+                        dplyr::distinct(), 
+                      by=c('id_proposicao','casa'))
+  
+  
+  readr::write_csv(av_iniciais, paste0(output_path, '/', 'avulsos_iniciais.csv'))
+  readr::write_csv(av_iniciais_novas_emendas, paste0(output_path, '/', 'avulsos_iniciais_novas_emendas.csv'))
+}

--- a/scripts/process_leggo_data.R
+++ b/scripts/process_leggo_data.R
@@ -1,5 +1,9 @@
 #!/usr/bin/env Rscript
+library(tidyverse)
 library(magrittr)
+source(here::here("scripts/documentos/export_atores.R"))
+source(here::here("scripts/documentos/export_coautorias.R"))
+source(here::here("scripts/documentos/export_emendas.R"))
 
 .HELP <- "
 Rscript process_leggo_data.R -i <input_path> -o <output_path> -d <data_inicial_documentos> -p <peso_minimo_arestas> -f <flag>
@@ -81,288 +85,13 @@ flag <- args$flag
 .PARTIDOS_OPOSICAO <-
   c("PT", "PSOL", "PSB", "PCdoB", "PDT", "REDE")
 
-#' @title Exporta dados de emendas para análise
-#' @description Processa e escreve os dados de emendas
-#' @param camara_docs documentos da camara
-#' @param senados_docs documentos do senado
-#' @param camara_autores autores da camara
-#' @param senado_autores autores do senado
-#' @param output_path pasta para onde exportar os dados
-#' @return dataframe com novas emendas a serem analisadas
-export_emendas <- function(camara_docs, camara_autores, senado_docs, senado_autores, output_path) {
-  print(paste("Gerando tabela de emendas para análise a partir de dados atualizados de documentos e autores..."))
-  
-  emendas_camara <- camara_docs %>% dplyr::filter(sigla_tipo %in% agoradigital::get_envvars_camara()$tipos_emendas$sigla) %>% 
-    dplyr::inner_join(camara_autores, by=c('id_documento','casa')) %>% 
-    dplyr::mutate(nome_partido_uf = paste0(nome, ' ', partido, '/', uf),
-                  data_apresentacao = as.Date(data_apresentacao)) %>% 
-    dplyr::group_by(id_ext = id_principal, 
-                    codigo_emenda = id_documento, 
-                    data_apresentacao, 
-                    numero, 
-                    local = status_proposicao_sigla_orgao, 
-                    casa, 
-                    tipo_documento = sigla_tipo,
-                    inteiro_teor = url_inteiro_teor) %>% 
-    dplyr::summarise(autor = paste(nome_partido_uf, collapse = ', ')) %>% 
-    dplyr::ungroup() %>% 
-    dplyr::select(id_ext, codigo_emenda, data_apresentacao, numero, local, autor, casa, tipo_documento, inteiro_teor)
-  
-  emendas_senado <- senado_docs %>% dplyr::filter(descricao_tipo_texto %in% agoradigital::get_envvars_senado()$tipos_emendas$descricao_tipo_texto) %>% 
-    dplyr::inner_join(senado_autores, by=c('id_principal','id_documento','casa')) %>% 
-    dplyr::mutate(nome_partido_uf = paste0(nome_autor, ' ', partido, '/', uf),
-                  numero = as.integer(numero_emenda),
-                  data_apresentacao = lubridate::ymd(data_texto)) %>% 
-    dplyr::group_by(id_ext = id_principal, 
-                    codigo_emenda = id_documento, 
-                    data_apresentacao, 
-                    numero, 
-                    local = identificacao_comissao_sigla_comissao, 
-                    casa, 
-                    tipo_documento = descricao_tipo_texto,
-                    inteiro_teor = url_texto) %>% 
-    dplyr::summarise(autor = paste(nome_partido_uf, collapse = ', ')) %>% 
-    dplyr::ungroup() %>% 
-    dplyr::select(id_ext, codigo_emenda, data_apresentacao, numero, local, autor, casa, tipo_documento, inteiro_teor)
-  
-  emendas <- dplyr::bind_rows(emendas_camara, emendas_senado)
-  
-  novas_emendas <- agoradigital::update_emendas_files(emendas, output_path)
-}
-
-#' @title Exporta dados de avulsos iniciais para análise
-#' @description Processa e escreve os dados de avulsos iniciais
-#' @param camara_docs documentos da camara
-#' @param senados_docs documentos do senado
-#' @param novas_emendas novas emendas a serem analisadas
-#' @param output_path pasta para onde exportar os dados
-export_avulsos_iniciais <- function(camara_docs, senado_docs, novas_emendas, output_path) {
-  print(paste("Gerando tabela de avulsos iniciais dos PLs para análise a partir de dados atualizados de documentos..."))
-  
-  av_iniciais_camara <- camara_docs %>% dplyr::filter(id_documento == id_principal) %>% 
-    dplyr::mutate(data = as.Date(data_apresentacao)) %>% 
-    dplyr::select(id_proposicao = id_principal,
-                  casa,
-                  codigo_texto = id_documento,
-                  data,
-                  tipo_texto = descricao_tipo_documento,
-                  inteiro_teor = url_inteiro_teor) %>% 
-    dplyr::distinct()
-  
-  
-  av_iniciais_senado <- senado_docs %>% dplyr::filter(stringr::str_detect(tolower(descricao_texto), 'avulso inicial da mat.ria')) %>% 
-    dplyr::select(id_proposicao = id_principal,
-                  casa,
-                  codigo_texto = id_documento,
-                  data = data_texto,
-                  tipo_texto = descricao_tipo_texto,
-                  inteiro_teor = url_texto)
-  
-  av_iniciais <- dplyr::bind_rows(av_iniciais_camara, av_iniciais_senado)
-  
-  av_iniciais_novas_emendas <- av_iniciais %>% 
-    dplyr::inner_join(novas_emendas %>% 
-                        dplyr::select(id_proposicao = id_ext, casa) %>% 
-                        dplyr::distinct(), 
-                      by=c('id_proposicao','casa'))
-    
-  
-  readr::write_csv(av_iniciais, paste0(output_path, '/', 'avulsos_iniciais.csv'))
-  readr::write_csv(av_iniciais_novas_emendas, paste0(output_path, '/', 'avulsos_iniciais_novas_emendas.csv'))
-}
-
-#' @title Exporta dados atores
-#' @description Processa e escreve os dados de atores
-#' @param camara_docs documentos da camara
-#' @param senados_docs documentos do senado
-#' @param camara_autores autores da camara
-#' @param senado_autores autores do senado
-#' @param data_inicial data a partir da qual se considerará os documentos
-#' @param peso_minimo limiar para peso dos documentos
-#' @param output_path pasta para onde exportar os dados
-export_atores <- function(camara_docs, camara_autores, senado_docs, senado_autores, output_path, data_inicio, peso_minimo, props_leggo_id) {
-  print(paste("Gerando tabela de atores a partir de dados atualizados de documentos e autores..."))
-
-  atores_camara <-
-    agoradigital::create_tabela_atores_camara(camara_docs, camara_autores, data_inicio = data_inicio, limiar = peso_minimo)
-  atores_senado <- agoradigital::create_tabela_atores_senado(senado_docs, senado_autores, data_inicio = data_inicio, limiar = peso_minimo)
-
-  if ((nrow(atores_camara) > 0) | (nrow(atores_senado) > 0)) {
-    atores_df <-
-      dplyr::bind_rows(atores_camara, atores_senado) %>%
-      dplyr::mutate(bancada = dplyr::if_else(partido %in% .PARTIDOS_OPOSICAO, "oposição", "governo")) %>%
-      dplyr::left_join(props_leggo_id, by = c("id_ext"="id_principal", "casa")) %>%
-      dplyr::select(id_leggo, dplyr::everything())
-  } else {
-    atores_df <- tibble::tribble(~id_leggo, ~id_ext, ~casa, ~id_autor, ~tipo_autor, ~tipo_generico, ~sigla_local,
-                                 ~peso_total_documentos, ~num_documentos, ~partido, ~uf, ~nome_autor, ~is_important, ~bancada)
-  }
-
-  readr::write_csv(atores_df, paste0(output_path, '/atores.csv'), na = "")
-}
-
-#' @title Exporta dados de autorias e coautorias na Câmara
-#' @description Processa e escreve os dados de autorias e coautorias na Câmara
-#' @param camara_docs documentos da camara
-#' @param data_inicial data a partir da qual se considerará os documentos
-#' @param camara_autores autores da camara
-#' @param peso_minimo limiar para peso das arestas
-#' @param props_leggo_id proposições a serem filtradas
-#' @param output_path caminho para onde os arquivos serão exportados
-.generate_coautorias_camara <- function(camara_docs, data_inicial, camara_autores, peso_minimo, props_leggo_id, output_path) {
-  coautorias_camara <- tibble::tibble()
-  autorias_camara <- tibble::tibble()
-
-  print("Gerando tabela de autorias e coautorias para a Câmara...")
-  
-  camara_documentos <-
-    camara_docs %>%
-    dplyr::mutate(data = lubridate::floor_date(data_apresentacao, unit='day')) %>%
-    dplyr::filter(data > data_inicial) %>%
-    dplyr::left_join(props_leggo_id, by = c("id_principal", "casa"))
-  
-  # Gerando dado de autorias de documentos
-  if (nrow(camara_documentos) > 0) {
-    coautorias_camara_list <- agoradigital::get_coautorias(camara_documentos, camara_autores, "camara", as.numeric(peso_minimo), .PARTIDOS_OPOSICAO)
-    coautorias_camara <- coautorias_camara_list$coautorias
-    autorias_camara <- coautorias_camara_list$autorias
-  }
-
-  if (nrow(coautorias_camara) > 0) {
-    coautorias <-
-      coautorias_camara %>%
-      dplyr::mutate(partido.x = dplyr::if_else(is.na(partido.x), "", partido.x),
-                    partido.y = dplyr::if_else(is.na(partido.y), "", partido.y))
-    
-    autorias <-
-      autorias_camara %>% 
-      dplyr::mutate(autores = purrr::map_chr(nome_eleitoral, ~ paste(.x, collapse = ", "))) %>% 
-      dplyr::distinct()
-    
-  } else {
-    coautorias <- tibble::tibble(~id_leggo, ~id_principal, ~casa, ~id_autor.x, ~id_autor.y, ~peso_arestas, ~num_coautorias, 
-                                  ~nome.x, ~partido.x, ~uf.x, ~bancada.x, ~nome.y, ~partido.y, ~uf.y, ~bancada.y)
-    autorias <- tibble::tribble(~id_documento, ~id_autor, ~descricao_tipo_documento, ~data, ~url_inteiro_teor, ~id_leggo, ~nome_eleitoral, ~autores)
-  }
-  
-  readr::write_csv(coautorias, paste0(output_path, '/camara/coautorias.csv'))
-  readr::write_csv(autorias, paste0(output_path, '/camara/autorias.csv'))
-}
-
-#' @title Exporta dados de autorias e coautorias no Senado
-#' @description Processa e escreve os dados de autorias e coautorias no Senado
-#' @param senados_docs documentos do senado
-#' @param data_inicial data a partir da qual se considerará os documentos
-#' @param senado_autores autores do senado
-#' @param peso_minimo limiar para peso das arestas
-#' @param props_leggo_id proposições a serem filtradas
-#' @param output_path pasta para onde exportar os dados
-.generate_coautorias_senado <- function(senado_docs, data_inicial, senado_autores, peso_minimo, props_leggo_id, output_path) {
-  coautorias_senado <- tibble::tibble()
-  autorias_senado <- tibble::tibble()
-  
-  print("Gerando tabela de autorias e coautorias no Senado...")
-  
-  senado_documentos <-
-    senado_docs %>%
-    dplyr::filter(data_texto > data_inicial) %>%
-    dplyr::left_join(props_leggo_id, by = c("id_principal", "casa"))
-  
-  # Gerando dado de autorias de documentos
-  if (nrow(senado_documentos) > 0) {
-    coautorias_senado_list <- agoradigital::get_coautorias(senado_documentos, senado_autores, "senado", as.numeric(peso_minimo), .PARTIDOS_OPOSICAO)
-    coautorias_senado <- coautorias_senado_list$coautorias
-    autorias_senado <- coautorias_senado_list$autorias
-  }
-  
-  if (nrow(coautorias_senado) > 0) {
-    coautorias <-
-      coautorias_senado %>%
-      dplyr::mutate(partido.x = dplyr::if_else(is.na(partido.x), "", partido.x),
-                    partido.y = dplyr::if_else(is.na(partido.y), "", partido.y))
-    
-    autorias <-
-      autorias_senado %>% 
-      dplyr::mutate(autores = purrr::map_chr(nome_eleitoral, ~ paste(.x, collapse = ", "))) %>% 
-      dplyr::distinct()
-    
-  } else {
-    coautorias <- tibble::tibble(~id_leggo, ~id_principal, ~casa, ~id_autor.x, ~id_autor.y, ~peso_arestas, ~num_coautorias, 
-                                 ~nome.x, ~partido.x, ~uf.x, ~bancada.x, ~nome.y, ~partido.y, ~uf.y, ~bancada.y)
-    autorias <- tibble::tribble(~id_documento, ~id_autor, ~descricao_tipo_documento, ~data, ~url_inteiro_teor, ~id_leggo, ~nome_eleitoral, ~autores)
-  }
-  
-  readr::write_csv(coautorias, paste0(output_path, '/senado/coautorias.csv'))
-  readr::write_csv(autorias, paste0(output_path, '/senado/autorias.csv'))
-}
-
-#' @title Exporta dados de nodes e edges
-#' @description Processa e escreve os dados de nodes e edges
-#' @param input_path pasta para onde importar os dados.
-#' @param camara_docs documentos da camara
-#' @param data_inicial data a partir da qual se considerará os documentos
-#' @param senados_docs documentos do senado
-#' @param camara_autores autores da camara
-#' @param peso_minimo limiar para peso das arestas
-#' @param senado_autores autores do senado
-#' @param output_path pasta para onde exportar os dados
-export_nodes_edges <- function(input_path, camara_docs, data_inicial, senado_docs, camara_autores, peso_minimo, senado_autores, props_leggo_id, output_path) {
-  
-  .generate_coautorias_camara(camara_docs, data_inicial, camara_autores, peso_minimo, props_leggo_id, output_path)
-  .generate_coautorias_senado(senado_docs, data_inicial, senado_autores, peso_minimo, props_leggo_id, output_path)
-
-  coautorias_camara <- readr::read_csv(paste0(output_path, '/camara/coautorias.csv'))
-  autorias_camara <- readr::read_csv(paste0(output_path, '/camara/autorias.csv'))
-  
-  coautorias_senado <- readr::read_csv(paste0(output_path, '/senado/coautorias.csv'))
-  autorias_senado <- readr::read_csv(paste0(output_path, '/senado/autorias.csv'))
-
-  if ((nrow(coautorias_camara) > 0) | (nrow(coautorias_senado) > 0)) {
-    
-    names(autorias_senado)
-    names(autorias_camara)
-    coautorias <-
-      rbind(coautorias_camara, coautorias_senado) %>%
-      dplyr::mutate(partido.x = dplyr::if_else(is.na(partido.x), "", partido.x),
-                    partido.y = dplyr::if_else(is.na(partido.y), "", partido.y))
-  
-    autorias <-
-      rbind(autorias_camara, autorias_senado) %>% 
-      dplyr::distinct()
-
-    nodes <-
-      agoradigital::get_unique_nodes(coautorias)
-    
-    edges <-
-      coautorias %>%
-      dplyr::group_by(id_leggo) %>%
-      dplyr::group_modify(~ agoradigital::generate_edges(., graph_nodes = nodes, edges_weight = 1), keep = T) %>%
-      dplyr::distinct()
-    
-    nodes <-
-      agoradigital::compute_nodes_size(edges, nodes)
-    
-    edges <-
-      edges %>%
-      dplyr::filter(source != target)
-  } else {
-    nodes <- tibble::tribble(~id_leggo, ~id_autor, ~nome, ~partido, ~uf, ~bancada, ~nome_eleitoral, ~node_size)
-    edges <- tibble::tribble(~id_leggo, ~source, ~target, ~value)
-    autorias <- tibble::tribble(~id_documento, ~id_autor, ~descricao_tipo_documento, ~data, ~url_inteiro_teor, ~id_leggo, ~nome_eleitoral, ~autores)
-  }
-  
-  readr::write_csv(nodes , paste0(output_path, '/coautorias_nodes.csv'), na = "")
-  readr::write_csv(edges, paste0(output_path, '/coautorias_edges.csv'), na = "")
-  readr::write_csv(autorias, paste0(output_path, '/autorias.csv'))
-}
-
 #' @title Chama as funções corretas
 #' @description Recebe uma flag e chama as funções correspondetes
 #' @param flag Inteiro que representa qual função o usuário desejar chamar
 process_leggo_data <- function(flag) {
   if (!(flag %in% c(1, 2, 3,4))) {
     stop(paste("Wrong flag!", .HELP, sep = "\n"))
-  }else {
+  } else {
     ## Install local repository R package version
     devtools::install(upgrade = "never")
 
@@ -371,8 +100,11 @@ process_leggo_data <- function(flag) {
       dplyr::mutate(casa = as.character(casa))
     camara_autores <-
       agoradigital::read_current_autores_camara(paste0(input_path, "/camara/autores.csv")) %>%
-      dplyr::mutate(id_documento = as.numeric(id_documento),
-                    nome = agoradigital::formata_nome_deputados(nome))
+      dplyr::mutate(id_documento = as.numeric(id_documento)) %>% 
+      rowwise() %>% 
+      dplyr::mutate(nome = agoradigital::formata_nome_deputados(nome, tipo_autor)) %>% 
+      ungroup()
+    
     senado_docs <-
       agoradigital::read_current_docs_senado(paste0(input_path, "/senado/documentos.csv")) %>%
       dplyr::mutate(id_documento = as.numeric(id_documento),
@@ -380,8 +112,10 @@ process_leggo_data <- function(flag) {
                     casa = as.character(casa))
     senado_autores <- 
       agoradigital::read_current_autores_senado(paste0(input_path, "/senado/autores.csv")) %>% 
+      rowwise() %>% 
       dplyr::mutate(nome_autor =
-                      agoradigital::formata_nome_senadores(nome_autor))
+                      agoradigital::formata_nome_senadores(nome_autor, tipo_autor)) %>% 
+      ungroup()
 
     props_leggo_id <-
       agoradigital::read_props(paste0(input_path, "/proposicoes.csv")) %>%

--- a/scripts/update_leggo_data.R
+++ b/scripts/update_leggo_data.R
@@ -227,6 +227,12 @@ if (casa == 'senado') {
       dplyr::mutate(nome = purrr::map_chr(ultimo_status_nome_eleitoral, ~ simpleCap(.x))) %>%
       dplyr::select(id_autor, nome, tipo_autor, uri_autor, id_documento, casa, partido, uf, cod_tipo_autor)
 
+    # remove id_principal para realizar novo join com documentos atualizados
+    if("id_principal" %in% (current_autores %>% names())) {
+      current_autores <- current_autores %>%
+        dplyr::select(-id_principal)
+    }
+
     updated_autores_docs <-
       dplyr::bind_rows(current_autores %>%
                          dplyr::mutate_all(as.character),

--- a/scripts/update_leggo_data.R
+++ b/scripts/update_leggo_data.R
@@ -139,8 +139,8 @@ if (casa == 'senado') {
     dplyr::rename(
       id_documento = codigo_texto,
       id_principal = codigo_materia
-    ) %>% 
-    distinct(id_principal, id_documento, .keep_all = TRUE)
+    ) %>%
+    dplyr::distinct(id_principal, id_documento, .keep_all = TRUE)
 
   senado_autores <-
     senado_autores %>%
@@ -149,10 +149,10 @@ if (casa == 'senado') {
       id_principal = codigo_materia
     )
 
-  senado_autores_com_id_autor <- agoradigital::match_autores_senado_to_parlamentares(senado_autores, senadores, deputados) %>% 
+  senado_autores_com_id_autor <- agoradigital::match_autores_senado_to_parlamentares(senado_autores, senadores, deputados) %>%
     dplyr::filter(!is.na(id_autor)) %>% ## filtra apenas autores com id
     dplyr::distinct(id_autor, id_principal, id_documento, .keep_all = TRUE)
-  
+
   print(paste("Salvando",nrow(senado_docs), "documentos para o Senado."))
   readr::write_csv(senado_docs, docs_filepath)
   print(paste("Salvando",nrow(senado_autores_com_id_autor), "autores de documentos para o Senado."))
@@ -210,7 +210,7 @@ if (casa == 'senado') {
 
     print(paste("Adicionando ",nrow(new_docs_data)," novos documentos."))
     updated_docs <-
-      dplyr::bind_rows(current_docs, new_docs_data %>% dplyr::filter(id_documento %in% complete_docs$id_documento)) %>% 
+      dplyr::bind_rows(current_docs, new_docs_data %>% dplyr::filter(id_documento %in% complete_docs$id_documento)) %>%
       dplyr::distinct(id_documento, .keep_all = TRUE)
 
     print(paste("Adicionando ",nrow(new_autores_data)," autores de novos documentos."))
@@ -222,17 +222,17 @@ if (casa == 'senado') {
     }
     matched_autores_data <-
       merge(new_autores_data, deputados, by.x = "id_autor", by.y = "id") %>%
-      dplyr::mutate(nome = purrr::map_chr(ultimo_status_nome_eleitoral, ~ simpleCap(.x))) %>% 
+      dplyr::mutate(nome = purrr::map_chr(ultimo_status_nome_eleitoral, ~ simpleCap(.x))) %>%
       dplyr::select(id_autor, nome, tipo_autor,uri_autor,id_documento,casa,partido,uf,cod_tipo_autor)
-    
+
     updated_autores_docs <-
-      dplyr::bind_rows(current_autores, matched_autores_data %>% dplyr::filter(id_documento %in% complete_docs$id_documento)) %>% 
-      dplyr::filter(tipo_autor == "Deputado" & casa == "camara") %>% 
-      dplyr::distinct(id_autor, id_documento, .keep_all = TRUE) %>% 
+      dplyr::bind_rows(current_autores, matched_autores_data %>% dplyr::filter(id_documento %in% complete_docs$id_documento)) %>%
+      dplyr::filter(tipo_autor == "Deputado" & casa == "camara") %>%
+      dplyr::distinct(id_autor, id_documento, .keep_all = TRUE) %>%
       dplyr::left_join(updated_docs %>% distinct(id_documento, id_principal),
-                       by = c("id_documento")) %>% 
+                       by = c("id_documento")) %>%
       dplyr::select(id_autor, id_documento, id_principal, dplyr::everything())
-    
+
     print("Salvando documentos e autores.")
     readr::write_csv(updated_docs, docs_filepath)
     readr::write_csv(updated_autores_docs, autores_filepath)

--- a/scripts/update_leggo_data.R
+++ b/scripts/update_leggo_data.R
@@ -139,7 +139,8 @@ if (casa == 'senado') {
     dplyr::rename(
       id_documento = codigo_texto,
       id_principal = codigo_materia
-    )
+    ) %>% 
+    distinct(id_principal, id_documento, .keep_all = TRUE)
 
   senado_autores <-
     senado_autores %>%
@@ -148,11 +149,17 @@ if (casa == 'senado') {
       id_principal = codigo_materia
     )
 
-  senado_autores_com_id_autor <- agoradigital::match_autores_senado_to_parlamentares(senado_autores, senadores, deputados)
+  senado_autores_com_id_autor <- agoradigital::match_autores_senado_to_parlamentares(senado_autores, senadores, deputados) %>% 
+    dplyr::filter(!is.na(id_autor)) %>% ## filtra apenas autores com id
+    dplyr::distinct(id_autor, id_principal, id_documento, .keep_all = TRUE)
+  
+  print(paste("Salvando",nrow(senado_docs), "documentos para o Senado."))
   readr::write_csv(senado_docs, docs_filepath)
+  print(paste("Salvando",nrow(senado_autores_com_id_autor), "autores de documentos para o Senado."))
   readr::write_csv(senado_autores_com_id_autor, autores_filepath)
+  print("Salvos :)")
 
-}else {
+} else {
   current_docs <- agoradigital::read_current_docs_camara(docs_filepath)
   current_autores <- agoradigital::read_current_autores_camara(autores_filepath)
 
@@ -202,10 +209,9 @@ if (casa == 'senado') {
     }
 
     print(paste("Adicionando ",nrow(new_docs_data)," novos documentos."))
-
     updated_docs <-
-      plyr::rbind.fill(current_docs, new_docs_data %>% dplyr::filter(id_documento %in% complete_docs$id_documento))
-    readr::write_csv(updated_docs, docs_filepath)
+      dplyr::bind_rows(current_docs, new_docs_data %>% dplyr::filter(id_documento %in% complete_docs$id_documento)) %>% 
+      dplyr::distinct(id_documento, .keep_all = TRUE)
 
     print(paste("Adicionando ",nrow(new_autores_data)," autores de novos documentos."))
 
@@ -218,9 +224,19 @@ if (casa == 'senado') {
       merge(new_autores_data, deputados, by.x = "id_autor", by.y = "id") %>%
       dplyr::mutate(nome = purrr::map_chr(ultimo_status_nome_eleitoral, ~ simpleCap(.x))) %>% 
       dplyr::select(id_autor, nome, tipo_autor,uri_autor,id_documento,casa,partido,uf,cod_tipo_autor)
+    
     updated_autores_docs <-
-      plyr::rbind.fill(current_autores, matched_autores_data %>% dplyr::filter(id_documento %in% complete_docs$id_documento))
+      dplyr::bind_rows(current_autores, matched_autores_data %>% dplyr::filter(id_documento %in% complete_docs$id_documento)) %>% 
+      dplyr::filter(tipo_autor == "Deputado" & casa == "camara") %>% 
+      dplyr::distinct(id_autor, id_documento, .keep_all = TRUE) %>% 
+      dplyr::left_join(updated_docs %>% distinct(id_documento, id_principal),
+                       by = c("id_documento")) %>% 
+      dplyr::select(id_autor, id_documento, id_principal, dplyr::everything())
+    
+    print("Salvando documentos e autores.")
+    readr::write_csv(updated_docs, docs_filepath)
     readr::write_csv(updated_autores_docs, autores_filepath)
+    print("Salvo.")
   } else {
     print("Não há documentos novos para essa proposição na Câmara.")
   }

--- a/tests/testthat/test-atores.R
+++ b/tests/testthat/test-atores.R
@@ -15,9 +15,11 @@ setup <- function() {
                                     descricao_tipo_documento = c('Emenda na Comissão', 'Emenda na Comissão', 'Requerimento de Audiência Pública'),
                                     status_proposicao_sigla_orgao = c('PLEN', 'CCJ', 'CFT'))
 
-  autores_sample_df_camara <<- tibble::tibble(id_documento = c(11,11,12,21,21),
+  autores_sample_df_camara <<- tibble::tibble(id_principal = c(1, 1, 1, 2, 2),
+                                       id_documento = c(11,11,12,21,21),
                                        casa = c('camara','camara','camara','camara','camara'),
                                        id_autor = c(1,5,5,5,6),
+                                       tipo_autor = c("deputado", "deputado", "deputado", "deputado", "deputado"),
                                        partido = c('PSDB','PT','PT','PT', 'PSL'),
                                        uf = c('SP', "PB", "PB", "PB", "BA"),
                                        nome = c('Dep. A', 'Dep. C', 'Dep. C', 'Dep. C', 'Dep. D'))
@@ -76,6 +78,7 @@ setup <- function() {
                                        id_documento = c(11,11,12,21,21),
                                        casa = c('senado','senado','senado','senado','senado'),
                                        id_autor = c(1,5,5,5,6),
+                                       tipo_autor = c("senador", "senador", "senador", "senador", "senador"),
                                        partido = c('PSDB','PT','PT','PT', 'PSL'),
                                        uf = c('SP', "PB", "PB", "PB", "BA"),
                                        nome_autor = c('Sen. A', 'Sen. C', 'Sen. C', 'Sen. C', 'Sen. D'))
@@ -122,7 +125,8 @@ setup <- function() {
   
   autores_docs <<- tibble::tibble(id_principal = rep(123,6), 
                                   casa = c("camara",rep("senado",2),rep("camara",3)), 
-                                  id_documento = c(1,rep(2,2),rep(3,3)))
+                                  id_documento = c(1,rep(2,2),rep(3,3)),
+                                  id_autor = c(31, 31, 32, 31, 32, 33))
   
   pesos_docs <<- tibble::tibble(id_principal = rep(123,3), 
                                 casa = c("camara","senado","camara"), 

--- a/tests/testthat/test-graph.R
+++ b/tests/testthat/test-graph.R
@@ -14,18 +14,20 @@ setup <- function() {
                                     url_inteiro_teor =c("google.com", "google.com", "google.com"),
                                     id_leggo = c(1, 1, 1))
   
-  autores_sample_df <<- tibble::tibble(id_documento = c(11,11,12,21,21),
+  autores_sample_df <<- tibble::tibble(id_principal = c(1, 1, 1, 2, 2),
+                                       id_documento = c(11,11,12,21,21),
                                        casa = c('camara','camara','camara','camara','camara'),
                                        id_autor = c(1,5,5,5,6),
+                                       tipo_autor = c("deputado", "deputado", "deputado", "deputado", "deputado"),
                                        partido = c('PSDB','PT','PT','PT', 'PSL'),
                                        uf = c('SP', "PB", "PB", "PB", "BA"),
                                        nome = c('Dep. A', 'Dep. C', 'Dep. C', 'Dep. C', 'Dep. D'))
   
   coautorias_sample <<-
-    tibble::tribble(~id_leggo, ~ id_principal, ~ casa, ~ id_autor.x, ~ id_autor.y, ~ peso_arestas, ~ num_coautorias, ~ nome.x, ~ partido.x, ~ uf.x, ~ bancada.x, ~ nome.y, ~ partido.y, ~ uf.y, ~ bancada.y,
-    1,            1, "camara",          1,          5,          0.5,              1, "Dep. A", "PSDB", "SP",    "governo",   "Dep. C", "PT", "PB",    "oposição",  
-    1,            1, "camara",          5,          5,          1,                1, "Dep. C", "PT", "PB",    "oposição",   "Dep. C", "PT", "PB",    "oposição",  
-    1,            2, "camara",          5,          6,          0.5,              1, "Dep. C", "PT", "PB",    "oposição",   "Dep. D", "PSL", "BA",    "governo" ) 
+    tibble::tribble(~id_leggo, ~ id_principal, ~ casa, ~ id_autor.x, ~ id_autor.y, ~ peso_arestas, ~ num_coautorias, ~ nome.x, ~ partido.x, ~ uf.x, ~casa_autor.x, ~ bancada.x, ~ nome.y, ~ partido.y, ~ uf.y, ~casa_autor.y, ~ bancada.y,
+    1,            1, "camara",          1,          5,          0.5,              1, "Dep. A", "PSDB", "SP", "camara",    "governo",   "Dep. C", "PT", "PB", "camara",    "oposição",  
+    1,            1, "camara",          5,          5,          1,                1, "Dep. C", "PT", "PB", "camara",    "oposição",   "Dep. C", "PT", "PB", "camara",    "oposição",  
+    1,            2, "camara",          5,          6,          0.5,              1, "Dep. C", "PT", "PB", "camara",    "oposição",   "Dep. D", "PSL", "BA", "camara",    "governo" ) 
   
   .OPOSICAO = c("PT")
     
@@ -35,10 +37,10 @@ setup <- function() {
     dplyr::mutate(num_coautorias = as.numeric(num_coautorias))
   
   nodes_sample <<-
-    tibble::tribble(~id_leggo, ~ id_autor, ~ nome, ~ partido, ~ uf, ~ bancada, ~ nome_eleitoral,        
-                    1,        1, "Dep. A", "PSDB", "SP",    "governo", "Dep. A (PSDB/SP)",
-                    1,        5, "Dep. C", "PT",    "PB",    "oposição", "Dep. C (PT/PB)", 
-                    1,        6, "Dep. D", "PSL",    "BA",    "governo", "Dep. D (PSL/BA)")
+    tibble::tribble(~id_leggo, ~ id_autor, ~ nome, ~ partido, ~ uf, ~ bancada, ~casa_autor, ~ nome_eleitoral,        
+                    1,        1, "Dep. A", "PSDB", "SP",    "governo", "camara", "Dep. A (PSDB/SP)",
+                    1,        5, "Dep. C", "PT",    "PB",    "oposição", "camara", "Dep. C (PT/PB)", 
+                    1,        6, "Dep. D", "PSL",    "BA",    "governo", "camara", "Dep. D (PSL/BA)")
   
   nodes <<-
     agoradigital::get_unique_nodes(coautorias_sample)
@@ -55,10 +57,10 @@ setup <- function() {
     dplyr::distinct()
   
   nodes_sample_with_size <<-
-    tibble::tribble(~id_leggo, ~ id_autor, ~ nome, ~ partido, ~ uf, ~ bancada, ~ nome_eleitoral, ~ node_size,        
-                    1,        1, "Dep. A", "PSDB", "SP",    "governo", "Dep. A (PSDB/SP)", 0.5,
-                    1,        5, "Dep. C", "PT",    "PB",    "oposição", "Dep. C (PT/PB)", 2,
-                    1,        6, "Dep. D", "PSL",    "BA",    "governo", "Dep. D (PSL/BA)", 0.5)
+    tibble::tribble(~id_leggo, ~ id_autor, ~ nome, ~ partido, ~ uf, ~ bancada, ~casa_autor, ~ nome_eleitoral, ~ node_size,        
+                    1,        1, "Dep. A", "PSDB", "SP",    "governo", "camara", "Dep. A (PSDB/SP)", 0.5,
+                    1,        5, "Dep. C", "PT",    "PB",    "oposição", "camara", "Dep. C (PT/PB)", 2,
+                    1,        6, "Dep. D", "PSL",    "BA",    "governo", "camara", "Dep. D (PSL/BA)", 0.5)
   
   nodes_with_size <<-
     agoradigital::compute_nodes_size(edges, nodes)

--- a/tests/testthat/test-proposicoes.R
+++ b/tests/testthat/test-proposicoes.R
@@ -10,12 +10,12 @@ setup <- function(){
 senado_autores <-
   tibble::tibble(id_principal = c(1,1,2),
                  id_documento = c(3, 4, 9),
-                 id_autor = c(31, 31, 31),
+                 id_autor = c(31, 31, 32),
                  casa = c("senado", "senado", "senado"),
                  nome_autor = c("Jair", "Guedes", "Romario"),
                  partido = c("p1", "p2", "p3"),
                  uf = c("PB", "PB", "PB"),
-                 tipo_autor = c("Deputado", "Deputado", "Deputado"))
+                 tipo_autor = c("Senador", "Senador", "Senador"))
 
 senado_docs <- 
   tibble::tibble(id_principal = c(1,1,2),
@@ -25,18 +25,18 @@ senado_docs <-
                  identificacao_comissao_nome_comissao = c("Comissão de Constituição, Justiça e Cidadania", "Comissão de Constituição, Justiça e Cidadania", "Comissão de Constituição, Justiça e Cidadania"))
 
 senado_atores_gabarito <-
-  tibble::tibble(id_ext = c(1, 1, 2),
-                 casa = c("senado", "senado", "senado"),
-                 id_autor = c(31, 31, 31),
-                 tipo_autor = c("senador", "senador", "senador"),
-                 nome_autor = c("Jair", "Guedes", "Romario"),
-                 partido = c("p1", "p2", "p3"),
-                 uf = c("PB", "PB", "PB"),
-                 tipo_generico = c("Emenda", "Emenda", "Emenda"),
-                 sigla_local = c("CCJ", "CCJ", "CCJ"),
-                 peso_total_documentos = c(1, 1, 1),
-                 num_documentos = as.integer(c(1,1,1)),
-                 is_important = c(TRUE, TRUE, TRUE))
+  tibble::tibble(id_ext = c(1, 2),
+                 casa = c("senado", "senado"),
+                 id_autor = c(31, 32),
+                 tipo_autor = c("Senador", "Senador"),
+                 nome_autor = c("Jair", "Romario"),
+                 partido = c("p1", "p3"),
+                 uf = c("PB", "PB"),
+                 tipo_generico = c("Emenda", "Emenda"),
+                 sigla_local = c("CCJ", "CCJ"),
+                 peso_total_documentos = c(2, 1),
+                 num_documentos = as.integer(c(2, 1)),
+                 is_important = c(TRUE, TRUE))
 
 pls_ids <- tibble::tibble(id_camara = c(257161,2088990),
                           id_senado = c(NA,91341),


### PR DESCRIPTION
## Mudanças
- Adiciona ids padronizados para os parlamentares considerando o enum da casa de origem
- Refatora geração e processamento dos dados do leggo para documentos
(autorias, atores, coautorias)
- Resolve bug de deputados que eram considerados senadores
- Conserta testes para refletir novo formato dos dados